### PR TITLE
Fix inline link preview checkbox displaying incorrect state

### DIFF
--- a/src/components/AppSettings.vue
+++ b/src/components/AppSettings.vue
@@ -293,8 +293,9 @@ export default {
         settingDefaultKickReason: bindSetting('buffers.default_kick_reason'),
         settingBufferInlineLinkPreviews: {
             get() {
-                return this.$state.setting('buffers.inline_link_auto_previews')
-                    || this.$state.setting('buffers.inline_link_auto_previews_query');
+                // Display checkbox state based on channel preview setting
+                // Setting it will update both channel and query settings
+                return this.$state.setting('buffers.inline_link_auto_previews');
             },
             set(newVal) {
                 this.$state.setting('buffers.inline_link_auto_previews', newVal);


### PR DESCRIPTION
The checkbox for inline link previews in AppSettings was showing as checked even when the setting was set to false in config.json.

Root cause: The getter used OR (||) operator between two settings, which returns true if either setting is true. This caused the checkbox to appear checked when at least one of the default values was true, regardless of config.json overrides.

Fix: Changed the getter to read only the channel preview setting (buffers.inline_link_auto_previews), while the setter continues to update both channel and query settings to maintain consistent behavior.

This ensures the checkbox correctly reflects the actual configuration and can be properly toggled by users.