### PR TITLE
Fix: Clean up network users when leaving channels

### DIFF
--- a/src/libs/IrcClient.js
+++ b/src/libs/IrcClient.js
@@ -599,9 +599,11 @@ function clientMiddleware(state, network) {
             state.removeUserFromBuffer(buffer, event.kicked);
 
             if (event.kicked === client.user.nick) {
+                let bufferUsers = Object.keys(buffer.users);
                 buffer.joined = false;
                 buffer.enabled = false;
                 buffer.clearUsers();
+                state.removeUsersWithNoCommonBuffers(networkid, bufferUsers);
             }
 
             let messageBody = '';
@@ -651,9 +653,11 @@ function clientMiddleware(state, network) {
 
             state.removeUserFromBuffer(buffer, event.nick);
             if (event.nick === client.user.nick) {
+                let bufferUsers = Object.keys(buffer.users);
                 buffer.joined = false;
                 buffer.enabled = false;
                 buffer.clearUsers();
+                state.removeUsersWithNoCommonBuffers(networkid, bufferUsers);
             }
 
             // Remove the user from network state if no remaining common channels

--- a/src/libs/state.js
+++ b/src/libs/state.js
@@ -562,12 +562,18 @@ function createNewState() {
                     this.openLastActiveBuffer();
                 }
 
-                // Remove this buffer from any users
+                // Remove this buffer from any users and collect nicks for cleanup
+                let bufferUserNicks = Object.keys(buffer.users);
                 /* eslint-disable guard-for-in */
                 Object.keys(buffer.users).forEach((nick) => {
                     let user = buffer.users[nick];
                     delete user.buffers[buffer.id];
                 });
+
+                // Clean up users that no longer share any buffers with us
+                if (buffer.isChannel()) {
+                    state.removeUsersWithNoCommonBuffers(network.id, bufferUserNicks);
+                }
             },
 
             addMessage(buffer, message) {
@@ -874,6 +880,31 @@ function createNewState() {
 
             removeUserFromBuffer(buffer, nick) {
                 buffer.removeUser(nick);
+            },
+
+            removeUsersWithNoCommonBuffers(networkid, usersToCheck) {
+                let network = this.getNetwork(networkid);
+                if (!network) {
+                    return;
+                }
+
+                if (usersToCheck) {
+                    usersToCheck.forEach((nick) => {
+                        let user = network.users[nick.toUpperCase()];
+                        if (!user) {
+                            return;
+                        }
+                        if (Object.keys(user.buffers).length === 0) {
+                            this.$delete(network.users, nick.toUpperCase());
+                        }
+                    });
+                } else {
+                    _.each(network.users, (user, nick) => {
+                        if (Object.keys(user.buffers).length === 0) {
+                            this.$delete(network.users, nick);
+                        }
+                    });
+                }
             },
 
             getBuffersWithUser(networkid, nick) {


### PR DESCRIPTION
Remove users from network.users object when they are no longer visible in any remaining buffers after leaving a channel. This prevents orphaned users from persisting in the global user list.

- Add removeUsersWithNoCommonBuffers() method to clean up users with no shared buffers
- Apply cleanup when buffer is removed (handles UI close and PART events)
- Apply cleanup in KICK handler to remove kicked users from other users' lists
- Apply cleanup in PART handler to handle /part command